### PR TITLE
Basic middle click support

### DIFF
--- a/src/main/kotlin/com/mineinabyss/blocky/BlockyPlugin.kt
+++ b/src/main/kotlin/com/mineinabyss/blocky/BlockyPlugin.kt
@@ -42,7 +42,8 @@ class BlockyPlugin : JavaPlugin() {
             BlockyTripwireListener(),
             BlockyChorusPlantListener(),
             BlockyItemFrameListener(),
-            WorldEditListener()
+            BlockyMiddleClickListener(),
+            WorldEditListener(),
         )
 
         gearyAddon {

--- a/src/main/kotlin/com/mineinabyss/blocky/listeners/BlockyMiddleClickListener.kt
+++ b/src/main/kotlin/com/mineinabyss/blocky/listeners/BlockyMiddleClickListener.kt
@@ -1,0 +1,34 @@
+package com.mineinabyss.blocky.listeners
+
+import com.mineinabyss.blocky.helpers.getPrefabFromBlock
+import com.mineinabyss.geary.prefabs.PrefabKey
+import com.mineinabyss.looty.LootyFactory
+import com.mineinabyss.looty.tracking.toGearyOrNull
+import org.bukkit.Material
+import org.bukkit.entity.Player
+import org.bukkit.event.EventHandler
+import org.bukkit.event.EventPriority
+import org.bukkit.event.Listener
+import org.bukkit.event.inventory.ClickType
+import org.bukkit.event.inventory.InventoryCreativeEvent
+
+class BlockyMiddleClickListener : Listener {
+    @EventHandler(priority = EventPriority.LOWEST)
+    fun InventoryCreativeEvent.test() {
+        if (click != ClickType.CREATIVE) return
+        if (cursor.type != Material.NOTE_BLOCK) return
+        val player = inventory.holder as? Player ?: return
+        //TODO if null, replace noteblock in with our custom noteblock (paper item)
+        val lookingAtPrefab = player.rayTraceBlocks(6.0)?.hitBlock?.getPrefabFromBlock() ?: return
+        val existingSlot = (0..8).firstOrNull {
+            player.inventory.getItem(it)?.toGearyOrNull(player)?.get<PrefabKey>() == lookingAtPrefab
+        }
+        if (existingSlot != null) {
+            player.inventory.heldItemSlot = existingSlot
+            isCancelled = true
+            return
+        }
+        player.inventory.heldItemSlot
+        cursor = LootyFactory.createFromPrefab(lookingAtPrefab) ?: return
+    }
+}


### PR DESCRIPTION
Main issue right now is the event also fires when adding a noteblock to the player inventory. So if one looks at a custom block when adding a noteblock, it replaces it.